### PR TITLE
update comment to use numpy style docstrings

### DIFF
--- a/dspftw/signal_correlation.py
+++ b/dspftw/signal_correlation.py
@@ -1,6 +1,7 @@
 # vim: expandtab tabstop=4 shiftwidth=4
 
-# Cross-Correlation with normalization set to default
+''' Cross-Correlation with normalization set to default
+'''
 
 from scipy.signal import convolve, correlate
 


### PR DESCRIPTION
Addresses #18 Changed comment at the top of signal_correlation.py to use numpy style docstring